### PR TITLE
Corrigindo um NullReference nesse ponto

### DIFF
--- a/src/Functions/CsvFunctions.cs
+++ b/src/Functions/CsvFunctions.cs
@@ -43,7 +43,7 @@ namespace DoIt.Functions
 			using (var fw = new FileStream(path, append ? FileMode.Append : FileMode.Create, FileAccess.Write))
 			using (var sw = new StreamWriter(fw, Encoding.Default)){
 				for (var x=0; x<lstColumns.Length; x++){
-					sw.Write("\""+ Program.Shared.ReplaceTags(lstColumns[x]).Replace("\"","\"\"")+"\"");
+					sw.Write("\""+ (Program.Shared.ReplaceTags(lstColumns[x]) ?? "").Replace("\"","\"\"")+"\"");
 					if (x < lstColumns.Length - 1)
 						sw.Write(separator);
 				}


### PR DESCRIPTION
Em alguns casos o valor estava vazio e o ReplaceTags retornava null ocasionando o NullReference ao tentar fazer o Replace